### PR TITLE
Ci/fix lint job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,6 @@
 name: Linting and Unit-test
 
 on:
-  push:
-    branches: [ master ]
   pull_request:
     branches: [ master ]
 
@@ -12,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - run: make lint
 
   test:


### PR DESCRIPTION
fixes #44 

### Observations
Due to the fact that GitHub action does a shallow clone of the repo (using `actions/checkout@v3`) the checked-out repository does not have a branch `master`. As a result, it gives `fatal: ambiguous argument 'origin/master'` error when `make lint` is run.

### Fix
By forcing `fetch-depth: 0` we can checkout the entire repo and the `origin/master` will be available. :blush: 

### Opinion
I am not getting the point of running `make lint` on `master` branch because the code that needs to be checked by the linter are in the current branch. Shouldn't we run the workflow on the `origin/current-PR-branch`? :pray: