### PR TITLE
Refactor environment classes

### DIFF
--- a/tests/units/environments/stablebaselines3/test_custom_env.py
+++ b/tests/units/environments/stablebaselines3/test_custom_env.py
@@ -1,0 +1,70 @@
+import unittest
+from unittest.mock import patch
+
+from urnai.environments.stablebaselines3.custom_env import CustomEnv
+
+
+class TestCustomEnv(unittest.TestCase):
+
+    def test_custom_env_init(self):
+        # GIVEN any state
+        # WHEN
+        env = CustomEnv(None, None, None, None, None, None)
+        # THEN
+        self.assertEqual(env._env, None)
+        self.assertEqual(env._state, None)
+        self.assertEqual(env._action_space, None)
+        self.assertEqual(env._reward, None)
+        self.assertEqual(env._obs, None)
+        self.assertEqual(env.action_space, None)
+        self.assertEqual(env.observation_space, None)
+    
+    @patch('urnai.rewards.reward_base.RewardBase')
+    @patch('urnai.actions.action_space_base.ActionSpaceBase')
+    @patch('urnai.states.state_base.StateBase')
+    @patch('urnai.environments.environment_base.EnvironmentBase')
+    def test_custom_env_step(self,env_mock, state_mock, action_space_mock, reward_mock):
+        # GIVEN
+        env = CustomEnv(env_mock, state_mock, action_space_mock, reward_mock, None,None)
+        env_mock.step.return_value = (None, None, None, None)
+        state_mock.update.return_value = None
+        reward_mock.get.return_value = None
+        # WHEN
+        step_return = env.step(None)
+        # THEN
+        env_mock.step.assert_called_once()
+        state_mock.update.assert_called_once()
+        reward_mock.get.assert_called_once()
+        self.assertEqual(step_return, (None, None, None, None, {}))
+    
+    @patch('urnai.environments.environment_base.EnvironmentBase')
+    @patch('urnai.states.state_base.StateBase')
+    def test_custom_env_reset(self, state_mock, env_mock):
+        # GIVEN
+        env = CustomEnv(env_mock, state_mock, None, None, None, None)
+        env_mock.reset.return_value = None
+        state_mock.update.return_value = None
+        # WHEN
+        reset_return = env.reset()
+        # THEN
+        env_mock.reset.assert_called_once()
+        state_mock.update.assert_called_once()
+        self.assertEqual(reset_return, (None, {}))
+    
+    def test_custom_env_render(self):
+        # GIVEN
+        env = CustomEnv(None, None, None, None, None, None)
+
+        # WHEN / THEN
+        with self.assertRaises(NotImplementedError):
+            env.render(None)
+    
+    @patch('urnai.environments.environment_base.EnvironmentBase')
+    def test_custom_env_close(self, env_mock):
+        # GIVEN
+        env = CustomEnv(env_mock, None, None, None, None, None)
+        # WHEN
+        close_return = env.close()
+        # THEN
+        env_mock.close.assert_called_once()
+        self.assertEqual(close_return, None)

--- a/tests/units/sc2/environments/test_sc2_environment.py
+++ b/tests/units/sc2/environments/test_sc2_environment.py
@@ -58,7 +58,7 @@ class TestSC2Environment(unittest.TestCase):
         obs = env.reset()
         # THEN
         env.env_instance.reset.assert_called_once()
-        assert isinstance(obs[0], NamedDict)
+        assert isinstance(obs, NamedDict)
     
     @patch('pysc2.env.sc2_env.SC2Env')
     def test_step_method(self, scenv_mock):
@@ -78,12 +78,12 @@ class TestSC2Environment(unittest.TestCase):
         obs, reward, terminated, truncated = env.step([actions.RAW_FUNCTIONS.no_op()])
         # THEN
         env.env_instance.step.assert_called_once_with([actions.RAW_FUNCTIONS.no_op()])
-        assert isinstance(obs[0], NamedDict)
-        assert obs[0].step_mul == 16
-        assert isinstance(obs[0].map_size, point.Point)
-        assert obs[0].map_size.x == 64
-        assert obs[0].map_size.y == 64
-        assert reward[0] == 0
+        assert isinstance(obs, NamedDict)
+        assert obs.step_mul == 16
+        assert isinstance(obs.map_size, point.Point)
+        assert obs.map_size.x == 64
+        assert obs.map_size.y == 64
+        assert reward == 0
         assert terminated is False
         assert truncated is False
 

--- a/urnai/environments/stablebaselines3/custom_env.py
+++ b/urnai/environments/stablebaselines3/custom_env.py
@@ -37,9 +37,9 @@ class CustomEnv(gym.Env):
 
         obs, reward, terminated, truncated = self._env.step(action)
 
-        self._obs = obs[0]
+        self._obs = obs
         obs = self._state.update(self._obs)
-        reward = self._reward.get(self._obs, reward[0], terminated, truncated)
+        reward = self._reward.get(self._obs, reward, terminated, truncated)
         info = {}
         return obs, reward, terminated, truncated, info
 
@@ -47,7 +47,7 @@ class CustomEnv(gym.Env):
             self, seed: int = None, options: dict = None
         ) -> GymResetReturn:
         obs = self._env.reset()
-        self._obs = obs[0]
+        self._obs = obs
         obs = self._state.update(self._obs)
         info = {}
         return obs, info

--- a/urnai/sc2/environments/sc2environment.py
+++ b/urnai/sc2/environments/sc2environment.py
@@ -74,17 +74,17 @@ class SC2Env(EnvironmentBase):
                 realtime=self.realtime,
             )
 
-    def step(self, action_list: list) -> tuple[list[list], list[int], bool, bool]:
+    def step(self, action_list: list) -> tuple[list, int, bool, bool]:
         timestep = self.env_instance.step(action_list)
         obs, reward, terminated, truncated = self._parse_timestep(timestep)
         self.terminated = terminated
         self.truncated = truncated
-        return obs, reward, terminated, truncated
+        return obs[0], reward[0], terminated, truncated
 
-    def reset(self) -> list[list]:
+    def reset(self) -> list:
         timestep = self.env_instance.reset()
         obs, *_ = self._parse_timestep(timestep)
-        return obs
+        return obs[0]
 
     def close(self) -> None:
         self.env_instance.close()


### PR DESCRIPTION
After complete, this PR should:

- [X] Change location of Stable Baselines3 `CustomEnv` class, and make its implementation more general to other environments implementations.
- [X] Simplify `SC2Env` class, making it return only one observation and reward at a time on the methods `step` and `reset`.
- [X] Add unit tests for `CustomEnv` class.