### PR TITLE
Remove outdated SC2Action

### DIFF
--- a/experiments/solves/solve_collectables_sb3.py
+++ b/experiments/solves/solve_collectables_sb3.py
@@ -5,20 +5,20 @@ import numpy as np
 
 sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
 
+import wandb
 from absl import app
 from gymnasium import spaces
 from pysc2.env import sc2_env
 from stable_baselines3 import PPO
 from stable_baselines3.common.monitor import Monitor
+from wandb.integration.sb3 import WandbCallback
 
-import wandb
 from urnai.environments.stablebaselines3.custom_env import CustomEnv
 from urnai.sc2.actions.collectables import CollectablesActionSpace
 from urnai.sc2.environments.sc2environment import SC2Env
 from urnai.sc2.rewards.collectables import CollectablesReward
 from urnai.sc2.states.collectables import CollectablesMethod, CollectablesState
 from urnai.trainers.stablebaselines3_trainer import SB3Trainer
-from wandb.integration.sb3 import WandbCallback
 
 
 def declare_wandb_run(config_dict : dict, run_id : str = None):

--- a/tests/units/sc2/actions/test_collectablesActionSpace.py
+++ b/tests/units/sc2/actions/test_collectablesActionSpace.py
@@ -4,7 +4,7 @@ from pysc2.lib import actions
 from pysc2.lib.named_array import NamedDict
 
 from urnai.sc2.actions.collectables import CollectablesActionSpace
-from urnai.sc2.actions.sc2_action import SC2Action
+from urnai.sc2.actions.sc2_actions import raw_functions_classes as sc2_actions
 
 EXAMPLE_OBSERVATION = NamedDict({
     'player': NamedDict({
@@ -37,8 +37,7 @@ EXAMPLE_OBSERVATION = NamedDict({
     ]
 })
 
-MOVE_LEFT_ACTION = SC2Action.run(actions.RAW_FUNCTIONS.Move_pt,
-                        'now', 0, [-1, 1])
+MOVE_LEFT_ACTION = sc2_actions["Move_pt"].run('now', 0, [-1, 1])
 
 class TestCollectablesActionSpace(unittest.TestCase):
 
@@ -145,8 +144,7 @@ class TestCollectablesActionSpace(unittest.TestCase):
         actionSpace.move_right(obs)
         # THEN
         assert actionSpace.pending_actions == [
-            SC2Action.run(actions.RAW_FUNCTIONS.Move_pt,
-                        'now', 0, [3, 1])]
+            sc2_actions["Move_pt"].run('now', 0, [3, 1])]
     
     def test_move_up(self):
         # GIVEN
@@ -156,8 +154,7 @@ class TestCollectablesActionSpace(unittest.TestCase):
         actionSpace.move_up(obs)
         # THEN
         assert actionSpace.pending_actions == [
-            SC2Action.run(actions.RAW_FUNCTIONS.Move_pt,
-                        'now', 0, [1, -1])]
+            sc2_actions["Move_pt"].run('now', 0, [1, -1])]
 
     def test_move_down(self):
         # GIVEN
@@ -167,8 +164,7 @@ class TestCollectablesActionSpace(unittest.TestCase):
         actionSpace.move_down(obs)
         # THEN
         assert actionSpace.pending_actions == [
-            SC2Action.run(actions.RAW_FUNCTIONS.Move_pt,
-                        'now', 0, [1, 3])]
+            sc2_actions["Move_pt"].run('now', 0, [1, 3])]
         
     def test_get_action_name_str_by_int(self):
         # GIVEN

--- a/urnai/sc2/actions/collectables.py
+++ b/urnai/sc2/actions/collectables.py
@@ -6,6 +6,7 @@ from urnai.actions.action_space_base import ActionSpaceBase
 from urnai.sc2.actions import sc2_actions_aux as scaux
 from urnai.sc2.actions.sc2_actions import raw_functions_classes as sc2_actions
 
+
 class CollectablesActionSpace(ActionSpaceBase):
 
     def __init__(self):

--- a/urnai/sc2/actions/collectables.py
+++ b/urnai/sc2/actions/collectables.py
@@ -1,17 +1,15 @@
 from statistics import mean
 
 from pysc2.env import sc2_env
-from pysc2.lib import actions
 
 from urnai.actions.action_space_base import ActionSpaceBase
 from urnai.sc2.actions import sc2_actions_aux as scaux
-from urnai.sc2.actions.sc2_action import SC2Action
-
+from urnai.sc2.actions.sc2_actions import raw_functions_classes as sc2_actions
 
 class CollectablesActionSpace(ActionSpaceBase):
 
     def __init__(self):
-        self.noaction = [actions.RAW_FUNCTIONS.no_op()]
+        self.noaction = [sc2_actions["no_op"].run()]
         self.move_number = 0
 
         self.hor_threshold = 2
@@ -46,7 +44,7 @@ class CollectablesActionSpace(ActionSpaceBase):
     def get_action(self, action_idx, obs):
         action = None
         if len(self.pending_actions) == 0:
-            action = [actions.RAW_FUNCTIONS.no_op()]
+            action = self.noaction
         else:
             action = [self.pending_actions.pop()]
         self.solve_action(action_idx, obs)
@@ -77,8 +75,8 @@ class CollectablesActionSpace(ActionSpaceBase):
 
         for unit in army:
             self.pending_actions.append(
-                SC2Action.run(actions.RAW_FUNCTIONS.Move_pt,
-                              'now', unit.tag, [new_army_x, new_army_y]))
+                sc2_actions["Move_pt"].run(
+                    'now', unit.tag,[new_army_x, new_army_y]))
 
     def move_right(self, obs):
         army = scaux.select_army(obs, sc2_env.Race.terran)
@@ -90,8 +88,8 @@ class CollectablesActionSpace(ActionSpaceBase):
 
         for unit in army:
             self.pending_actions.append(
-                SC2Action.run(actions.RAW_FUNCTIONS.Move_pt, 
-                              'now', unit.tag, [new_army_x, new_army_y]))
+                sc2_actions["Move_pt"].run(
+                    'now', unit.tag,[new_army_x, new_army_y]))
 
     def move_down(self, obs):
         army = scaux.select_army(obs, sc2_env.Race.terran)
@@ -103,8 +101,8 @@ class CollectablesActionSpace(ActionSpaceBase):
 
         for unit in army:
             self.pending_actions.append(
-                SC2Action.run(actions.RAW_FUNCTIONS.Move_pt,
-                              'now', unit.tag, [new_army_x, new_army_y]))
+                sc2_actions["Move_pt"].run(
+                    'now', unit.tag,[new_army_x, new_army_y]))
 
     def move_up(self, obs):
         army = scaux.select_army(obs, sc2_env.Race.terran)
@@ -116,8 +114,8 @@ class CollectablesActionSpace(ActionSpaceBase):
 
         for unit in army:
             self.pending_actions.append(
-                SC2Action.run(actions.RAW_FUNCTIONS.Move_pt,
-                              'now', unit.tag, [new_army_x, new_army_y]))
+                sc2_actions["Move_pt"].run(
+                    'now', unit.tag,[new_army_x, new_army_y]))
 
     def get_action_name_str_by_int(self, action_int):
         action_str = ''


### PR DESCRIPTION
After a recent merge, there were still parts of the code that utilized the old class `SC2Action` for actions.