### PR TITLE
Deep Mind State class

### DIFF
--- a/tests/units/sc2/states/test_deepmind_state.py
+++ b/tests/units/sc2/states/test_deepmind_state.py
@@ -1,0 +1,476 @@
+import unittest
+from unittest.mock import Mock, patch
+
+import numpy as np
+from pysc2.lib import features
+
+from urnai.sc2.states.deepmind_state import DeepmindState
+
+
+class TestUtilityMethods(unittest.TestCase):
+    """Test low-level utility methods"""
+    
+    def setUp(self):
+        self.state = DeepmindState()
+    
+    def test_one_hot_encode_channel(self):
+        # GIVEN
+        height = 3
+        width = 3
+        num_classes = 4
+        channel_value = 2
+        channel = np.full((height, width), channel_value, dtype=np.float32)
+
+        # WHEN
+        one_hot_encoded = self.state._one_hot_encode_channel(channel, num_classes)
+
+        # THEN
+        self.assertEqual(one_hot_encoded.shape, (num_classes, height, width))
+        for i in range(num_classes):
+            expected_value = 1 if i == channel_value else 0
+            np.testing.assert_array_equal(
+                one_hot_encoded[i], np.full((height, width), expected_value)
+            )
+    
+    @patch('urnai.sc2.states.deepmind_state.DeepmindState.get_cached_conv1x1')
+    def test_conv1x1(self, mock_get_cached_conv1x1):
+        # GIVEN
+        in_channels = 3
+        out_channels = 2
+        height = 4
+        width = 4
+        input_array = np.arange(in_channels * height * width, dtype=np.float32).reshape(
+            in_channels, height, width
+        )
+
+        expected_output = np.ones((out_channels, height, width))
+        mock_conv = Mock()
+        mock_conv.return_value.detach.return_value.numpy.return_value = expected_output
+        mock_get_cached_conv1x1.return_value = mock_conv
+
+        # WHEN
+        result = self.state.conv1x1(in_channels, out_channels, input_array)
+
+        # THEN
+        mock_get_cached_conv1x1.assert_called_once_with(in_channels, out_channels)
+        np.testing.assert_array_equal(result, expected_output)
+
+    @patch('torch.nn.Conv2d')
+    def test_get_cached_conv1x1(self, mock_conv2d_class):
+        # GIVEN
+        in_channels = 5
+        out_channels = 3
+        
+        # WHEN
+        conv1 = self.state.get_cached_conv1x1(in_channels, out_channels)
+        conv2 = self.state.get_cached_conv1x1(in_channels, out_channels)  # Second call
+        
+        # THEN
+        self.assertIs(conv1, conv2)  # Same instance should be returned
+        mock_conv2d_class.assert_called_once_with(
+            in_channels, out_channels, kernel_size=1
+        )
+
+
+class TestChannelProcessing(unittest.TestCase):
+    """Test channel separation and processing methods"""
+    
+    def setUp(self):
+        self.state = DeepmindState()
+        self.height = 4
+        self.width = 4
+    
+    def test_separate_raw_channels_by_type_minimap(self):
+        # GIVEN
+        feature_specs = features.MINIMAP_FEATURES
+        spatial_data = np.arange(
+            len(feature_specs) * self.height * self.width, dtype=np.float32
+        ).reshape(len(feature_specs), self.height, self.width)
+
+        # WHEN
+        categorical_items, numerical_items = self.state._separate_raw_channels_by_type(
+            spatial_data, feature_specs
+        )
+
+        # THEN
+        categorical_count = sum(
+            1 for spec in feature_specs if spec.type == features.FeatureType.CATEGORICAL
+        )
+        numerical_count = len(feature_specs) - categorical_count
+        
+        self.assertEqual(len(categorical_items), categorical_count)
+        self.assertEqual(len(numerical_items), numerical_count)
+
+    def test_separate_raw_channels_by_type_screen(self):
+        # GIVEN
+        feature_specs = features.SCREEN_FEATURES
+        spatial_data = np.arange(
+            len(feature_specs) * self.height * self.width, dtype=np.float32
+        ).reshape(len(feature_specs), self.height, self.width)
+
+        # WHEN
+        categorical_items, numerical_items = self.state._separate_raw_channels_by_type(
+            spatial_data, feature_specs
+        )
+
+        # THEN
+        categorical_count = sum(
+            1 for spec in feature_specs if spec.type == features.FeatureType.CATEGORICAL
+        )
+        numerical_count = len(feature_specs) - categorical_count
+        
+        self.assertEqual(len(categorical_items), categorical_count)
+        self.assertEqual(len(numerical_items), numerical_count)
+
+    def test_separate_raw_channels_by_type_size_mismatch(self):
+        # GIVEN
+        feature_specs = [Mock(), Mock(), Mock()]  # 3 specs
+        spatial_data = np.arange(
+            2 * self.height * self.width, dtype=np.float32
+        ).reshape(2, self.height, self.width)  # 2 channels
+
+        # WHEN & THEN
+        with self.assertRaises(ValueError) as context:
+            self.state._separate_raw_channels_by_type(spatial_data, feature_specs)
+        
+        self.assertIn("Channel count mismatch", str(context.exception))
+
+    def test_process_numerical_channels(self):
+        # GIVEN
+        numerical_items = [
+            (np.full((self.height, self.width), 10.0, dtype=np.float32), Mock()),
+            (np.full((self.height, self.width), 5.0, dtype=np.float32), Mock()),
+        ]
+
+        # WHEN
+        result = self.state._process_numerical_channels(numerical_items)
+
+        # THEN
+        self.assertEqual(result.shape, (2, self.height, self.width))
+        expected_0 = np.log1p(10.0)
+        expected_1 = np.log1p(5.0)
+        np.testing.assert_array_almost_equal(
+            result[0], np.full((self.height, self.width), expected_0)
+        )
+        np.testing.assert_array_almost_equal(
+            result[1], np.full((self.height, self.width), expected_1)
+        )
+
+    def test_process_empty_numerical_channels(self):
+        # GIVEN
+        numerical_items = []
+
+        # WHEN
+        result = self.state._process_numerical_channels(numerical_items)
+
+        # THEN
+        self.assertIsNone(result)
+
+    @patch('urnai.sc2.states.deepmind_state.DeepmindState._one_hot_encode_channel')
+    @patch('urnai.sc2.states.deepmind_state.DeepmindState.conv1x1')
+    def test_process_categorical_channels(self, mock_conv1x1, mock_one_hot_encode):
+        # GIVEN
+        conv_output_channels = 4
+        state = DeepmindState(categorical_conv_channels=conv_output_channels)
+        num_classes_list = [3, 4, 2]
+        feature_specs_list = [
+            Mock(scale=num_classes_list[0]),
+            Mock(scale=num_classes_list[1]),
+            Mock(scale=num_classes_list[2])
+        ]
+        categorical_items = [
+            (np.full((self.height, self.width), 0), feature_specs_list[0]),
+            (np.full((self.height, self.width), 1), feature_specs_list[1]),
+            (np.full((self.height, self.width), 0), feature_specs_list[2])
+        ]
+        
+        one_hot_outputs = [
+            np.zeros((num_classes_list[0], self.height, self.width), dtype=np.float32),
+            np.zeros((num_classes_list[1], self.height, self.width), dtype=np.float32),
+            np.zeros((num_classes_list[2], self.height, self.width), dtype=np.float32)
+        ]
+        one_hot_outputs[0][0] = 1
+        one_hot_outputs[1][1] = 1
+        one_hot_outputs[2][0] = 1
+        
+        mock_one_hot_encode.side_effect = one_hot_outputs
+        
+        concatenated_one_hot = np.concatenate(one_hot_outputs, axis=0)
+        
+        conv_output = np.zeros(
+            (conv_output_channels, self.height, self.width), dtype=np.float32
+        )
+        for i in range(conv_output_channels):
+            conv_output[i] = i + 1
+        
+        mock_conv1x1.return_value = conv_output
+
+        # WHEN
+        processed_categorical = state._process_categorical_channels(categorical_items)
+
+        # THEN
+        self.assertEqual(
+            processed_categorical.shape, (conv_output_channels, self.height, self.width)
+        )
+        np.testing.assert_array_equal(processed_categorical, conv_output)
+        
+        self.assertEqual(mock_one_hot_encode.call_count, len(categorical_items))
+        for i, (expected_channel, spec) in enumerate(categorical_items):
+            call_args = mock_one_hot_encode.call_args_list[i][0]
+            called_channel = call_args[0]
+            called_num_classes = call_args[1]
+            
+            np.testing.assert_array_equal(called_channel, expected_channel)
+            self.assertEqual(called_num_classes, spec.scale)
+        
+        # Check conv1x1 was called once with correct arguments
+        mock_conv1x1.assert_called_once()
+        call_args = mock_conv1x1.call_args[0]
+        self.assertEqual(call_args[0], sum(num_classes_list))
+        self.assertEqual(call_args[1], state.categorical_out_conv_channels)
+        np.testing.assert_array_equal(call_args[2], concatenated_one_hot)
+
+    def test_process_categorical_channels_empty(self):
+        # GIVEN
+        categorical_items = []
+
+        # WHEN
+        result = self.state._process_categorical_channels(categorical_items)
+
+        # THEN
+        self.assertIsNone(result)
+
+    def test_combine_all_channels(self):
+        # GIVEN
+        processed_categorical = np.ones((2, self.height, self.width), dtype=np.float32)
+        processed_numerical = np.full(
+            (3, self.height, self.width), 2.0, dtype=np.float32
+        )
+        spatial_shape = (self.height, self.width)
+
+        # WHEN
+        result = self.state._combine_all_channels(
+            processed_categorical, processed_numerical, spatial_shape
+        )
+
+        # THEN
+        self.assertEqual(result.shape, (5, self.height, self.width))
+        np.testing.assert_array_equal(result[:2], processed_categorical)
+        np.testing.assert_array_equal(result[2:], processed_numerical)
+
+    def test_combine_all_channels_empty(self):
+        # GIVEN
+        processed_categorical = None
+        processed_numerical = None
+        spatial_shape = (self.height, self.width)
+
+        # WHEN
+        result = self.state._combine_all_channels(
+            processed_categorical, processed_numerical, spatial_shape
+        )
+
+        # THEN
+        self.assertEqual(result.shape, (0, self.height, self.width))
+
+
+class TestSpatialFeatures(unittest.TestCase):
+    """Test spatial feature processing (screen and minimap)"""
+    
+    def setUp(self):
+        self.state = DeepmindState()
+    
+    @patch('urnai.sc2.states.deepmind_state.DeepmindState._process_spatial_features')
+    def test_process_screen(self, mock_process_spatial_features):
+        # GIVEN
+        obs = {'feature_screen': np.array([[[1, 2], [3, 4]]])}
+        expected_result = np.array([[[5, 6], [7, 8]]])
+        mock_process_spatial_features.return_value = expected_result
+
+        # WHEN
+        result = self.state.process_screen(obs)
+
+        # THEN
+        mock_process_spatial_features.assert_called_once_with(
+            obs['feature_screen'], features.SCREEN_FEATURES
+        )
+        np.testing.assert_array_equal(result, expected_result)
+
+    @patch('urnai.sc2.states.deepmind_state.DeepmindState._process_spatial_features')
+    def test_process_minimap(self, mock_process_spatial_features):
+        # GIVEN
+        obs = {'feature_minimap': np.array([[[1, 2], [3, 4]]])}
+        expected_result = np.array([[[5, 6], [7, 8]]])
+        mock_process_spatial_features.return_value = expected_result
+
+        # WHEN
+        result = self.state.process_minimap(obs)
+
+        # THEN
+        mock_process_spatial_features.assert_called_once_with(
+            obs['feature_minimap'], features.MINIMAP_FEATURES
+        )
+        np.testing.assert_array_equal(result, expected_result)
+
+    def test_process_spatial_features(self):
+        # GIVEN
+        height = 4
+        width = 4
+        feature_specs = [
+            Mock(type=features.FeatureType.CATEGORICAL, scale=3),
+            Mock(type=features.FeatureType.SCALAR, scale=10),
+            Mock(type=features.FeatureType.CATEGORICAL, scale=2),
+            Mock(type=features.FeatureType.SCALAR, scale=5)
+        ]
+        raw_features = np.arange(
+            len(feature_specs) * height * width, dtype=np.float32
+            ).reshape((len(feature_specs), height, width))
+        
+        expected_categorical_items = [
+            (raw_features[0], feature_specs[0]),
+            (raw_features[2], feature_specs[2])
+        ]
+        expected_numerical_items = [
+            (raw_features[1], feature_specs[1]),
+            (raw_features[3], feature_specs[3])
+        ]
+        
+        processed_categorical = np.full(
+            (self.state.categorical_out_conv_channels, height, width), 
+            1.0, 
+            dtype=np.float32
+        )
+        processed_numerical = np.full((2, height, width), 2.0, dtype=np.float32)
+
+        with patch.object(
+            self.state, '_separate_raw_channels_by_type'
+        ) as mock_separate, \
+             patch.object(self.state, '_process_categorical_channels') as mock_cat, \
+             patch.object(self.state, '_process_numerical_channels') as mock_num, \
+             patch.object(self.state, '_combine_all_channels') as mock_combine:
+            
+            mock_separate.return_value = (
+                expected_categorical_items, expected_numerical_items
+            )
+            mock_cat.return_value = processed_categorical
+            mock_num.return_value = processed_numerical
+            mock_combine.return_value = np.concatenate(
+                [processed_categorical, processed_numerical], axis=0
+            )
+
+            # WHEN
+            result = self.state._process_spatial_features(raw_features, feature_specs)
+
+            # THEN
+            mock_separate.assert_called_once_with(raw_features, feature_specs)
+            mock_cat.assert_called_once_with(expected_categorical_items)
+            mock_num.assert_called_once_with(expected_numerical_items)
+            mock_combine.assert_called_once_with(
+                processed_categorical, processed_numerical, (height, width)
+            )
+            self.assertIsNotNone(result)
+
+
+class TestNonSpatialFeatures(unittest.TestCase):
+    """Test non-spatial feature processing"""
+    
+    def setUp(self):
+        self.state = DeepmindState()
+    
+    def test_process_non_spatial(self):
+        # GIVEN
+        player_data = np.array([100, 200, 50], dtype=np.int32)
+        obs = {'player': player_data}
+
+        # WHEN
+        result = self.state.process_non_spatial(obs)
+
+        # THEN
+        expected = np.log1p(player_data.astype(np.float32))
+        np.testing.assert_array_equal(result, expected)
+
+
+class TestStateManagement(unittest.TestCase):
+    """Test state management and dimension handling"""
+    
+    def setUp(self):
+        self.state = DeepmindState()
+    
+    def test_update_and_dimension(self):
+        # GIVEN
+        screen_array = np.ones((5, 64, 64), dtype=np.float32)
+        minimap_array = np.ones((7, 64, 64), dtype=np.float32)
+        player_array = np.array([1.0, 2.0, 3.0], dtype=np.float32)
+
+        with patch.object(self.state, 'process_screen') as mock_screen, \
+             patch.object(self.state, 'process_minimap') as mock_minimap, \
+             patch.object(self.state, 'process_non_spatial') as mock_non_spatial:
+            
+            mock_screen.return_value = screen_array
+            mock_minimap.return_value = minimap_array
+            mock_non_spatial.return_value = player_array
+
+            obs = {'fake': 'observation'}
+
+            # WHEN
+            self.state.update(obs)
+
+            # THEN
+            self.assertIsNotNone(self.state._state)
+            self.assertEqual(len(self.state._state), 3)
+            np.testing.assert_array_equal(self.state._state[0], screen_array)
+            np.testing.assert_array_equal(self.state._state[1], minimap_array)
+            np.testing.assert_array_equal(self.state._state[2], player_array)
+
+            dims = self.state.dimension
+            self.assertEqual(dims[0], screen_array.shape)
+            self.assertEqual(dims[1], minimap_array.shape)
+            self.assertEqual(dims[2], player_array.shape)
+
+    def test_dimension_no_state(self):
+        # GIVEN
+        # State is None by default
+
+        # WHEN
+        dims = self.state.dimension
+
+        # THEN
+        self.assertIsNone(dims)
+
+    def test_dimension_invalid_state(self):
+        # GIVEN
+        self.state._state = [1, 2]  # Invalid state with wrong length
+
+        # WHEN
+        dims = self.state.dimension
+
+        # THEN
+        self.assertIsNone(dims)
+
+    def test_state_property_initial_none(self):
+        # GIVEN
+        # State is None by default after initialization
+
+        # WHEN
+        result = self.state.state
+
+        # THEN
+        self.assertIsNone(result)
+
+    def test_state_property_after_update(self):
+        # GIVEN
+        expected_state = [
+            np.ones((5, 64, 64), dtype=np.float32),  # screen
+            np.ones((7, 64, 64), dtype=np.float32),  # minimap
+            np.array([1.0, 2.0, 3.0], dtype=np.float32)  # player
+        ]
+        self.state._state = expected_state
+
+        # WHEN
+        result = self.state.state
+
+        # THEN
+        self.assertIs(result, expected_state)  # Should return the same object reference
+        self.assertEqual(len(result), 3)
+        np.testing.assert_array_equal(result[0], expected_state[0])
+        np.testing.assert_array_equal(result[1], expected_state[1])
+        np.testing.assert_array_equal(result[2], expected_state[2])

--- a/urnai/sc2/states/deepmind_state.py
+++ b/urnai/sc2/states/deepmind_state.py
@@ -11,7 +11,7 @@ from urnai.states.state_base import StateBase
 class DeepmindState(StateBase):
     """State processor used by DeepMind for StarCraft II observations."""
 
-    def __init__(self, categorical_conv_channels: int = 8, 
+    def __init__(self, categorical_conv_channels: int = 1, 
                  normalize_data: bool = False):
         self.categorical_out_conv_channels = categorical_conv_channels
         self.normalize_data = normalize_data

--- a/urnai/sc2/states/deepmind_state.py
+++ b/urnai/sc2/states/deepmind_state.py
@@ -1,0 +1,76 @@
+import numpy as np
+from pysc2.lib import features
+
+from urnai.states.state_base import StateBase
+
+
+class DeepmindState(StateBase):
+
+    def __init__(self):
+        self.reset()
+
+    def reset(self):
+        self._state = None
+        self._dimension = None
+    
+    @property
+    def state(self):
+        return self._state
+
+    @property
+    def dimension(self):
+        screen_dims = self._state["screen"].shape
+        minimap_dims = self._state["minimap"].shape
+        non_spatial_dims = self._state["non_spatial"].shape
+        return (screen_dims, minimap_dims, non_spatial_dims)
+
+    def update(self, obs):
+        """
+        Pré-processa a observação do PySC2 de acordo com as especificações.
+        Retorna um dicionário contendo os tensores para screen, minimap e player.
+        """
+
+        processed_screen = self.process_screen(obs)
+        processed_minimap = self.process_minimap(obs)
+        processed_non_spatial = self.process_non_spatial(obs)
+
+        self._state = {
+            "screen": processed_screen,   # [C', H, W]
+            "minimap": processed_minimap, # [C'', H, W]
+            "non_spatial": processed_non_spatial    # [n_features]
+        }
+        return self._state
+
+    def process_screen(self, obs):
+        screen = obs["feature_screen"]
+        screen_processed = []
+        for i, spec in enumerate(features.SCREEN_FEATURES):
+            channel = screen[i].astype(np.float32)
+            processed_channel = self.process_channel(channel, spec)
+            screen_processed.append(processed_channel)
+        screen_processed = np.concatenate(screen_processed, axis=0)  # [C', H, W]
+        return screen_processed
+    
+    def process_minimap(self, obs):
+        minimap = obs["feature_minimap"]
+        minimap_processed = []
+        for i, spec in enumerate(features.MINIMAP_FEATURES):
+            channel = minimap[i].astype(np.float32)
+            processed_channel = self.process_channel(channel, spec)
+            minimap_processed.append(processed_channel)
+        minimap_processed = np.concatenate(minimap_processed, axis=0)
+        return minimap_processed
+
+    def process_channel(self, channel, spec):
+        if spec.type == features.FeatureType.CATEGORICAL:
+            one_hot = np.eye(spec.scale, dtype=np.float32)[channel]
+            one_hot = np.transpose(one_hot, (2, 0, 1))
+            return one_hot
+        else:
+            channel = np.log1p(channel)
+            return channel[None, :, :]
+
+    def process_non_spatial(self, obs):
+        player = obs["player"]
+        player_processed = np.log1p(player.astype(np.float32))
+        return player_processed

--- a/urnai/sc2/states/deepmind_state.py
+++ b/urnai/sc2/states/deepmind_state.py
@@ -18,6 +18,7 @@ class DeepmindState(StateBase):
     def reset(self):
         self._state = None
         self._dimension = None
+        self._conv_cache = {}
 
     @property
     def state(self):
@@ -50,6 +51,18 @@ class DeepmindState(StateBase):
         list[tuple[np.ndarray, features.Feature]],
         list[tuple[np.ndarray, features.Feature]]
     ]:
+        # Validate input dimensions
+        n_channels = spatial_data.shape[0]
+        n_features = len(feature_specs)
+        
+        if n_channels != n_features:
+            raise ValueError(
+                f"Channel count mismatch: spatial_data has {n_channels} channels "
+                f"but feature_specs expects {n_features} features. "
+                f"This usually indicates a PySC2 version mismatch or incorrect "
+                f"environment configuration."
+            )
+        
         categorical_items = []
         numerical_items = []
         
@@ -63,6 +76,16 @@ class DeepmindState(StateBase):
                 
         return categorical_items, numerical_items
     
+    def _one_hot_encode_channel(
+        self,
+        channel: np.ndarray,
+        num_classes: int
+    ) -> np.ndarray:
+        channel_int = channel.astype(np.int32)
+        one_hot = np.eye(num_classes, dtype=np.float32)[channel_int]
+        one_hot = np.transpose(one_hot, (2, 0, 1))
+        return one_hot
+    
     def _process_categorical_channels(
         self,
         categorical_items: list[tuple[np.ndarray, features.Feature]]
@@ -73,10 +96,7 @@ class DeepmindState(StateBase):
         # Apply one-hot encoding to all categorical channels
         one_hot_channels = []
         for channel, spec in categorical_items:
-            # Convert to integer indices for one-hot encoding
-            channel_int = channel.astype(np.int32)
-            one_hot = np.eye(spec.scale, dtype=np.float32)[channel_int]
-            one_hot = np.transpose(one_hot, (2, 0, 1))  # [scale, H, W]
+            one_hot = self._one_hot_encode_channel(channel, spec.scale)
             one_hot_channels.append(one_hot)
             
         # Concatenate all one-hot encoded channels
@@ -164,8 +184,24 @@ class DeepmindState(StateBase):
         out_channels: int,
         channels: np.ndarray
     ) -> np.ndarray:
-        conv = nn.Conv2d(in_channels, out_channels, kernel_size=1)
+        conv = self.get_cached_conv1x1(in_channels, out_channels)
         return conv(torch.from_numpy(channels)).detach().numpy()
+
+    def get_cached_conv1x1(
+        self,
+        in_channels: int,
+        out_channels: int
+    ) -> np.ndarray:
+        key = (in_channels, out_channels)
+        if key not in self._conv_cache:
+            unique_seed = 42 + in_channels * 1000 + out_channels
+            state = torch.get_rng_state()
+            torch.manual_seed(unique_seed)
+            self._conv_cache[key] = nn.Conv2d(in_channels, out_channels, kernel_size=1)
+            torch.set_rng_state(state)
+
+        conv = self._conv_cache[key]
+        return conv
 
     def process_non_spatial(self, obs: dict[str, Any]) -> np.ndarray:
         player = obs["player"]

--- a/urnai/sc2/states/deepmind_state.py
+++ b/urnai/sc2/states/deepmind_state.py
@@ -1,18 +1,24 @@
+from typing import Any
+
 import numpy as np
+import torch
+import torch.nn as nn
 from pysc2.lib import features
 
 from urnai.states.state_base import StateBase
 
 
 class DeepmindState(StateBase):
+    """State processor used by DeepMind for StarCraft II observations."""
 
-    def __init__(self):
+    def __init__(self, categorical_conv_channels: int = 8):
+        self.categorical_out_conv_channels = categorical_conv_channels
         self.reset()
 
     def reset(self):
         self._state = None
         self._dimension = None
-    
+
     @property
     def state(self):
         return self._state
@@ -25,52 +31,141 @@ class DeepmindState(StateBase):
         return (screen_dims, minimap_dims, non_spatial_dims)
 
     def update(self, obs):
-        """
-        Pré-processa a observação do PySC2 de acordo com as especificações.
-        Retorna um dicionário contendo os tensores para screen, minimap e player.
-        """
-
         processed_screen = self.process_screen(obs)
         processed_minimap = self.process_minimap(obs)
         processed_non_spatial = self.process_non_spatial(obs)
 
         self._state = {
-            "screen": processed_screen,   # [C', H, W]
-            "minimap": processed_minimap, # [C'', H, W]
+            "screen": processed_screen,       # [C', H, W]
+            "minimap": processed_minimap,     # [C'', H, W]
             "non_spatial": processed_non_spatial    # [n_features]
         }
         return self._state
 
-    def process_screen(self, obs):
-        screen = obs["feature_screen"]
-        screen_processed = []
-        for i, spec in enumerate(features.SCREEN_FEATURES):
-            channel = screen[i].astype(np.float32)
-            processed_channel = self.process_channel(channel, spec)
-            screen_processed.append(processed_channel)
-        screen_processed = np.concatenate(screen_processed, axis=0)  # [C', H, W]
-        return screen_processed
+    def _separate_raw_channels_by_type(
+        self,
+        spatial_data: np.ndarray,
+        feature_specs: list
+    ) -> tuple[
+        list[tuple[np.ndarray, features.Feature]],
+        list[tuple[np.ndarray, features.Feature]]
+    ]:
+        categorical_items = []
+        numerical_items = []
+        
+        for i, spec in enumerate(feature_specs):
+            channel = spatial_data[i].astype(np.float32)
+            
+            if spec.type == features.FeatureType.CATEGORICAL:
+                categorical_items.append((channel, spec))
+            else:
+                numerical_items.append((channel, spec))
+                
+        return categorical_items, numerical_items
     
-    def process_minimap(self, obs):
-        minimap = obs["feature_minimap"]
-        minimap_processed = []
-        for i, spec in enumerate(features.MINIMAP_FEATURES):
-            channel = minimap[i].astype(np.float32)
-            processed_channel = self.process_channel(channel, spec)
-            minimap_processed.append(processed_channel)
-        minimap_processed = np.concatenate(minimap_processed, axis=0)
-        return minimap_processed
-
-    def process_channel(self, channel, spec):
-        if spec.type == features.FeatureType.CATEGORICAL:
+    def _process_categorical_channels(
+        self,
+        categorical_items: list[tuple[np.ndarray, features.Feature]]
+    ) -> np.ndarray:
+        if not categorical_items:
+            return None
+            
+        # Apply one-hot encoding to all categorical channels
+        one_hot_channels = []
+        for channel, spec in categorical_items:
             one_hot = np.eye(spec.scale, dtype=np.float32)[channel]
-            one_hot = np.transpose(one_hot, (2, 0, 1))
-            return one_hot
-        else:
-            channel = np.log1p(channel)
-            return channel[None, :, :]
+            one_hot = np.transpose(one_hot, (2, 0, 1))  # [scale, H, W]
+            one_hot_channels.append(one_hot)
+            
+        # Concatenate all one-hot encoded channels
+        cat_combined = np.concatenate(one_hot_channels, axis=0)
+        
+        # Apply conv1x1 to reduce dimensions
+        return self.conv1x1(
+            cat_combined.shape[0], 
+            self.categorical_out_conv_channels, 
+            cat_combined
+        )
+    
+    def _process_numerical_channels(
+        self,
+        numerical_items: list[tuple[np.ndarray, features.Feature]]
+    ) -> np.ndarray:
+        if not numerical_items:
+            return None
+            
+        processed_channels = []
+        for channel, _ in numerical_items:
+            # Apply log transformation and add channel dimension
+            processed_channel = np.log1p(channel)
+            processed_channel = processed_channel[None, :, :]  # Add channel dimension
+            processed_channels.append(processed_channel)
 
-    def process_non_spatial(self, obs):
+        return np.concatenate(processed_channels, axis=0)
+    
+    def _combine_all_channels(
+        self,
+        processed_categorical: np.ndarray,
+        processed_numerical: np.ndarray,
+        spatial_shape: tuple[int, int]
+    ) -> np.ndarray:
+        all_channels = []
+        
+        if processed_categorical is not None and processed_categorical.size > 0:
+            all_channels.append(processed_categorical)
+        
+        if processed_numerical is not None and processed_numerical.size > 0:
+            all_channels.append(processed_numerical)
+
+        if all_channels:
+            return np.concatenate(all_channels, axis=0)
+        else:
+            # Return empty array with correct shape if no channels
+            height, width = spatial_shape
+            return np.zeros((0, height, width), dtype=np.float32)
+
+    def _process_spatial_features(
+        self,
+        spatial_data: np.ndarray,
+        feature_specs: list
+    ) -> np.ndarray:
+        categorical_items, numerical_items = self._separate_raw_channels_by_type(
+            spatial_data, feature_specs
+        )
+        
+        processed_categorical = self._process_categorical_channels(categorical_items)
+        
+        processed_numerical = self._process_numerical_channels(numerical_items)
+
+        spatial_shape = (spatial_data.shape[1], spatial_data.shape[2])
+        return self._combine_all_channels(
+            processed_categorical, processed_numerical, spatial_shape
+        )
+
+    def process_screen(self, obs):
+        """Process screen features using the generic spatial processing method."""
+        return self._process_spatial_features(
+            obs["feature_screen"], 
+            features.SCREEN_FEATURES
+        )
+
+    def process_minimap(self, obs):
+        """Process minimap features using the generic spatial processing method."""
+        return self._process_spatial_features(
+            obs["feature_minimap"], 
+            features.MINIMAP_FEATURES
+        )
+
+    def conv1x1(
+        self,
+        in_channels: int,
+        out_channels: int,
+        channels: np.ndarray
+    ) -> np.ndarray:
+        conv = nn.Conv2d(in_channels, out_channels, kernel_size=1)
+        return conv(torch.from_numpy(channels)).detach().numpy()
+
+    def process_non_spatial(self, obs: dict[str, Any]) -> np.ndarray:
         player = obs["player"]
         player_processed = np.log1p(player.astype(np.float32))
         return player_processed

--- a/urnai/sc2/states/deepmind_state.py
+++ b/urnai/sc2/states/deepmind_state.py
@@ -11,8 +11,10 @@ from urnai.states.state_base import StateBase
 class DeepmindState(StateBase):
     """State processor used by DeepMind for StarCraft II observations."""
 
-    def __init__(self, categorical_conv_channels: int = 8):
+    def __init__(self, categorical_conv_channels: int = 8, 
+                 normalize_data: bool = False):
         self.categorical_out_conv_channels = categorical_conv_channels
+        self.normalize_data = normalize_data
         self.reset()
 
     def reset(self):
@@ -49,6 +51,43 @@ class DeepmindState(StateBase):
         ]
         return self._state
 
+    def process_screen(self, obs):
+        """Process screen features using the generic spatial processing method."""
+        return self._process_spatial_features(
+            obs["feature_screen"], 
+            features.SCREEN_FEATURES
+        )
+
+    def process_minimap(self, obs):
+        """Process minimap features using the generic spatial processing method."""
+        return self._process_spatial_features(
+            obs["feature_minimap"], 
+            features.MINIMAP_FEATURES
+        )
+    
+    def process_non_spatial(self, obs: dict[str, Any]) -> np.ndarray:
+        player = obs["player"]
+        player_processed = np.log1p(player.astype(np.float32))
+        return player_processed
+
+    def _process_spatial_features(
+        self,
+        spatial_data: np.ndarray,
+        feature_specs: list
+    ) -> np.ndarray:
+        categorical_items, numerical_items = self._separate_raw_channels_by_type(
+            spatial_data, feature_specs
+        )
+        
+        processed_categorical = self._process_categorical_channels(categorical_items)
+        
+        processed_numerical = self._process_numerical_channels(numerical_items)
+
+        spatial_shape = (spatial_data.shape[1], spatial_data.shape[2])
+        return self._combine_all_channels(
+            processed_categorical, processed_numerical, spatial_shape
+        )
+
     def _separate_raw_channels_by_type(
         self,
         spatial_data: np.ndarray,
@@ -82,16 +121,6 @@ class DeepmindState(StateBase):
                 
         return categorical_items, numerical_items
     
-    def _one_hot_encode_channel(
-        self,
-        channel: np.ndarray,
-        num_classes: int
-    ) -> np.ndarray:
-        channel_int = channel.astype(np.int32)
-        one_hot = np.eye(num_classes, dtype=np.float32)[channel_int]
-        one_hot = np.transpose(one_hot, (2, 0, 1))
-        return one_hot
-    
     def _process_categorical_channels(
         self,
         categorical_items: list[tuple[np.ndarray, features.Feature]]
@@ -114,7 +143,7 @@ class DeepmindState(StateBase):
             self.categorical_out_conv_channels, 
             cat_combined
         )
-    
+
     def _process_numerical_channels(
         self,
         numerical_items: list[tuple[np.ndarray, features.Feature]]
@@ -130,7 +159,7 @@ class DeepmindState(StateBase):
             processed_channels.append(processed_channel)
 
         return np.concatenate(processed_channels, axis=0)
-    
+
     def _combine_all_channels(
         self,
         processed_categorical: np.ndarray,
@@ -152,37 +181,15 @@ class DeepmindState(StateBase):
             height, width = spatial_shape
             return np.zeros((0, height, width), dtype=np.float32)
 
-    def _process_spatial_features(
+    def _one_hot_encode_channel(
         self,
-        spatial_data: np.ndarray,
-        feature_specs: list
+        channel: np.ndarray,
+        num_classes: int
     ) -> np.ndarray:
-        categorical_items, numerical_items = self._separate_raw_channels_by_type(
-            spatial_data, feature_specs
-        )
-        
-        processed_categorical = self._process_categorical_channels(categorical_items)
-        
-        processed_numerical = self._process_numerical_channels(numerical_items)
-
-        spatial_shape = (spatial_data.shape[1], spatial_data.shape[2])
-        return self._combine_all_channels(
-            processed_categorical, processed_numerical, spatial_shape
-        )
-
-    def process_screen(self, obs):
-        """Process screen features using the generic spatial processing method."""
-        return self._process_spatial_features(
-            obs["feature_screen"], 
-            features.SCREEN_FEATURES
-        )
-
-    def process_minimap(self, obs):
-        """Process minimap features using the generic spatial processing method."""
-        return self._process_spatial_features(
-            obs["feature_minimap"], 
-            features.MINIMAP_FEATURES
-        )
+        channel_int = channel.astype(np.int32)
+        one_hot = np.eye(num_classes, dtype=np.float32)[channel_int]
+        one_hot = np.transpose(one_hot, (2, 0, 1))
+        return one_hot
 
     def conv1x1(
         self,
@@ -208,8 +215,3 @@ class DeepmindState(StateBase):
 
         conv = self._conv_cache[key]
         return conv
-
-    def process_non_spatial(self, obs: dict[str, Any]) -> np.ndarray:
-        player = obs["player"]
-        player_processed = np.log1p(player.astype(np.float32))
-        return player_processed

--- a/urnai/sc2/states/deepmind_state.py
+++ b/urnai/sc2/states/deepmind_state.py
@@ -26,9 +26,15 @@ class DeepmindState(StateBase):
 
     @property
     def dimension(self):
-        screen_dims = self._state["screen"].shape
-        minimap_dims = self._state["minimap"].shape
-        non_spatial_dims = self._state["non_spatial"].shape
+        if self._state is None:
+            return None
+        
+        if not isinstance(self._state, list) or len(self._state) != 3:
+            return None
+            
+        screen_dims = self._state[0].shape if self._state[0] is not None else None
+        minimap_dims = self._state[1].shape if self._state[1] is not None else None
+        non_spatial_dims = self._state[2].shape if self._state[2] is not None else None
         return (screen_dims, minimap_dims, non_spatial_dims)
 
     def update(self, obs):
@@ -36,11 +42,11 @@ class DeepmindState(StateBase):
         processed_minimap = self.process_minimap(obs)
         processed_non_spatial = self.process_non_spatial(obs)
 
-        self._state = {
-            "screen": processed_screen,       # [C', H, W]
-            "minimap": processed_minimap,     # [C'', H, W]
-            "non_spatial": processed_non_spatial    # [n_features]
-        }
+        self._state = [
+            processed_screen,       # [C', H, W]
+            processed_minimap,      # [C'', H, W]
+            processed_non_spatial   # [n_features]
+        ]
         return self._state
 
     def _separate_raw_channels_by_type(

--- a/urnai/sc2/states/deepmind_state.py
+++ b/urnai/sc2/states/deepmind_state.py
@@ -73,7 +73,9 @@ class DeepmindState(StateBase):
         # Apply one-hot encoding to all categorical channels
         one_hot_channels = []
         for channel, spec in categorical_items:
-            one_hot = np.eye(spec.scale, dtype=np.float32)[channel]
+            # Convert to integer indices for one-hot encoding
+            channel_int = channel.astype(np.int32)
+            one_hot = np.eye(spec.scale, dtype=np.float32)[channel_int]
             one_hot = np.transpose(one_hot, (2, 0, 1))  # [scale, H, W]
             one_hot_channels.append(one_hot)
             
@@ -110,10 +112,10 @@ class DeepmindState(StateBase):
         spatial_shape: tuple[int, int]
     ) -> np.ndarray:
         all_channels = []
-        
+
         if processed_categorical is not None and processed_categorical.size > 0:
             all_channels.append(processed_categorical)
-        
+
         if processed_numerical is not None and processed_numerical.size > 0:
             all_channels.append(processed_numerical)
 


### PR DESCRIPTION
When complete, this PR should try to implement the same State representation used by DeepMind on the _Atari-net Agent_, proposed on their [article](https://arxiv.org/pdf/1708.04782).

To improve visualization, these pictures give an example of the transformation of the observation into the desired state:

- Non-spatial features: apply a numerical re-escale into every element;
<img width="859" height="309" alt="image" src="https://github.com/user-attachments/assets/dc26d97e-d431-44bd-a440-a4ba07594ac3" />

- Minimap feature layers: separate categorical layers from scalar layers. On the categorical, apply one-hot encoding, followed by 1x1 convolution. On the scalar, apply the numerical re-escale;
<img width="1259" height="423" alt="image" src="https://github.com/user-attachments/assets/76969b22-66a5-49bd-8476-61a3dfa9fc01" />

- Screen feature layers: same processing as minimap feature layers.
<img width="1254" height="416" alt="image" src="https://github.com/user-attachments/assets/85e691b5-509e-4a64-96c8-014e86628250" />
