### PR TITLE
Add Invalid Action Masking from sb3-contrib

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -14,5 +14,6 @@ dependencies:
   - numpy=1.26.4
   - pip:
       - pysc2==4.0.0
+      - sb3-contrib==2.0.0
 platforms:
   - linux-64

--- a/urnai/sc2/environments/sc2environment.py
+++ b/urnai/sc2/environments/sc2environment.py
@@ -1,3 +1,6 @@
+import sys
+
+from absl import flags
 from pysc2.env import sc2_env
 from pysc2.env.environment import TimeStep
 from pysc2.lib import actions, features
@@ -25,6 +28,7 @@ class SC2Env(EnvironmentBase):
     ):
         super().__init__(map_name, visualize, reset_done)
 
+        flags.FLAGS(sys.argv)
         self.step_mul = step_mul
         self.game_steps_per_episode = game_steps_per_episode
         self.spatial_dim = spatial_dim

--- a/urnai/trainers/stablebaselines3_trainer.py
+++ b/urnai/trainers/stablebaselines3_trainer.py
@@ -1,7 +1,7 @@
 import os
 
+from sb3_contrib.common.maskable.evaluation import evaluate_policy
 from stable_baselines3.common.base_class import BaseAlgorithm
-from stable_baselines3.common.evaluation import evaluate_policy
 from stable_baselines3.common.type_aliases import MaybeCallback
 
 from urnai.environments.stablebaselines3.custom_env import CustomEnv
@@ -12,13 +12,14 @@ from urnai.logging.wandb_logger import WandbLoggingMode
 class SB3Trainer:
     def __init__(self, train_env : CustomEnv, eval_env : CustomEnv, models_dir : str, 
                  logdir : str, model : BaseAlgorithm, model_name : str, 
-                 logger : LoggerBase = None):
+                 logger : LoggerBase = None, use_masking : bool = False) -> None:
         self.train_env = train_env
         self.eval_env = eval_env
         self.models_dir = models_dir
         self.model = model
         self.model_name = model_name
         self.logger = logger
+        self.use_masking = use_masking
 
         if not os.path.exists(models_dir):
             os.makedirs(models_dir)
@@ -75,7 +76,8 @@ class SB3Trainer:
                         callback=callback,
                         reward_threshold=reward_threshold,
                         return_episode_rewards=return_episode_rewards,
-                        warn=warn
+                        warn=warn,
+                        use_masking=self.use_masking
                         )
         
         return episode_rewards


### PR DESCRIPTION
This pull request introduces support for maskable policies from the `sb3-contrib` library in the training and evaluation workflow. 

It allows the use of [MaskablePPO](https://sb3-contrib.readthedocs.io/en/master/modules/ppo_mask.html) in the training of agents. An example of usage can be found [here](https://sb3-contrib.readthedocs.io/en/master/modules/ppo_mask.html#example).